### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_and_deploy_image.yml
+++ b/.github/workflows/publish_and_deploy_image.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+        uses: elgohr/Publish-Docker-Github-Action@v5
         if: github.event.inputs.SKIP_PUBLISH_DOCKER_IMAGE != 'true'
         with:
           name: highperformancecomputing/cte


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore